### PR TITLE
Add blocking checkout with waiter queue

### DIFF
--- a/src/bath.gleam
+++ b/src/bath.gleam
@@ -786,12 +786,12 @@ fn handle_pool_message(state: State(resource_type), msg: Msg(resource_type)) {
                 // Otherwise, create a new resource, warning if resource creation fails
                 Eager -> {
                   case state.create_resource() {
-                    // Size hasn't changed
+                    // Resource replaced: +1 offsets earlier decrement, net pool size unchanged
                     Ok(resource) -> #(
                       deque.push_back(state.resources, resource),
                       current_size + 1,
                     )
-                    // Size has changed
+                    // Resource lost: pool size decreased by 1
                     Error(resource_create_error) -> {
                       log_resource_creation_error(
                         state.log_errors,


### PR DESCRIPTION
First, thank you for releasing this. Feel free to ignore this and close it if it doesn't align with your project design. I am working on a system where I need a pool of resources, but I also need to have the requestor block (up to some timeout) if a resource isn't available. I first tried to write it with bath but ran into this issue. I ended up switching to poolboy via some FFI.

Introduce apply_blocking that waits for resources when the pool is exhausted instead of returning NoResourcesAvailable immediately.